### PR TITLE
feat(auth): implement API endpoints and password reset functionality

### DIFF
--- a/apps/rogs_comm/lib/rogs_comm_web/router.ex
+++ b/apps/rogs_comm/lib/rogs_comm_web/router.ex
@@ -1,6 +1,8 @@
 defmodule RogsCommWeb.Router do
   use RogsCommWeb, :router
 
+  import RogsIdentity.Plug
+
   pipeline :browser do
     plug :accepts, ["html"]
     plug :fetch_session
@@ -8,6 +10,11 @@ defmodule RogsCommWeb.Router do
     plug :put_root_layout, html: {RogsCommWeb.Layouts, :root}
     plug :protect_from_forgery
     plug :put_secure_browser_headers
+    plug :fetch_current_user
+  end
+
+  pipeline :authenticated do
+    plug :require_authenticated
   end
 
   pipeline :api do

--- a/apps/rogs_comm/mix.exs
+++ b/apps/rogs_comm/mix.exs
@@ -44,6 +44,7 @@ defmodule RogsComm.MixProject do
   # Type `mix help deps` for examples and options.
   defp deps do
     [
+      {:rogs_identity, in_umbrella: true},
       {:phoenix, "~> 1.8.1"},
       {:phoenix_ecto, "~> 4.5"},
       {:ecto_sql, "~> 3.13"},

--- a/apps/rogs_identity/lib/rogs_identity.ex
+++ b/apps/rogs_identity/lib/rogs_identity.ex
@@ -5,11 +5,49 @@ defmodule RogsIdentity do
 
   Contexts are also responsible for managing your data, regardless
   if it comes from the database, an external API or others.
+
+  ## Usage in Other Apps
+
+  This module provides functions that can be called from other apps
+  in the umbrella project (rogs_comm, shinkanki_web, etc.).
+
+  ### Getting User Information
+
+      # Get user by ID
+      user = RogsIdentity.get_user(user_id)
+
+      # Get display name
+      name = RogsIdentity.get_display_name(user_id)
+
+  ### Authentication Plugs
+
+  Use `RogsIdentity.Plug` in your router:
+
+      import RogsIdentity.Plug
+
+      pipeline :browser do
+        plug :accepts, ["html"]
+        plug :fetch_session
+        plug :fetch_current_user
+      end
+
+      pipeline :require_authenticated do
+        plug :require_authenticated
+      end
+
+  ### Session Sharing
+
+  Sessions are shared via cookies. Make sure all apps run on the same domain
+  or configure cookie domain appropriately in production.
   """
 
+  alias RogsIdentity.Accounts
   alias RogsIdentity.Accounts.User
 
-  defdelegate get_user(id), to: RogsIdentity.Accounts
+  defdelegate get_user(id), to: Accounts
+  defdelegate get_user!(id), to: Accounts
+  defdelegate get_user_by_email(email), to: Accounts
+  defdelegate get_user_by_session_token(token), to: Accounts
 
   @doc """
   Gets the display name for a user by ID.
@@ -31,4 +69,26 @@ defmodule RogsIdentity do
       user -> User.display_name(user)
     end
   end
+
+  @doc """
+  Checks if a user is authenticated based on the session token.
+  Returns the user if authenticated, nil otherwise.
+
+  ## Examples
+
+      iex> get_authenticated_user(session_token)
+      %User{}
+
+      iex> get_authenticated_user(invalid_token)
+      nil
+
+  """
+  def get_authenticated_user(token) when is_binary(token) do
+    case Accounts.get_user_by_session_token(token) do
+      {user, _token_inserted_at} -> user
+      nil -> nil
+    end
+  end
+
+  def get_authenticated_user(_), do: nil
 end

--- a/apps/rogs_identity/lib/rogs_identity/accounts.ex
+++ b/apps/rogs_identity/lib/rogs_identity/accounts.ex
@@ -321,6 +321,45 @@ defmodule RogsIdentity.Accounts do
   end
 
   @doc """
+  Delivers the password reset instructions to the given user.
+  """
+  def deliver_password_reset_instructions(%User{} = user, reset_url_fun)
+      when is_function(reset_url_fun, 1) do
+    {encoded_token, user_token} = UserToken.build_email_token(user, "reset_password")
+    Repo.insert!(user_token)
+    UserNotifier.deliver_password_reset_instructions(user, reset_url_fun.(encoded_token))
+  end
+
+  @doc """
+  Gets the user by password reset token.
+  """
+  def get_user_by_password_reset_token(token) do
+    with {:ok, query} <- UserToken.verify_password_reset_token_query(token),
+         {user, _token} <- Repo.one(query) do
+      user
+    else
+      _ -> nil
+    end
+  end
+
+  @doc """
+  Resets the user password using the given token.
+  """
+  def reset_user_password(token, attrs) do
+    with user when not is_nil(user) <- get_user_by_password_reset_token(token),
+         {:ok, query} <- UserToken.verify_password_reset_token_query(token),
+         {_user, user_token} <- Repo.one(query),
+         {:ok, user} <- update_user_password(user, attrs) do
+      # Delete the reset token after successful password reset
+      Repo.delete(user_token)
+      {:ok, user}
+    else
+      nil -> {:error, :invalid_token}
+      _ -> {:error, :invalid_token}
+    end
+  end
+
+  @doc """
   Deletes the signed token with the given context.
   """
   def delete_user_session_token(token) do

--- a/apps/rogs_identity/lib/rogs_identity/accounts/user_notifier.ex
+++ b/apps/rogs_identity/lib/rogs_identity/accounts/user_notifier.ex
@@ -81,4 +81,26 @@ defmodule RogsIdentity.Accounts.UserNotifier do
     ==============================
     """)
   end
+
+  @doc """
+  Deliver instructions to reset password.
+  """
+  def deliver_password_reset_instructions(user, url) do
+    deliver(user.email, "Reset password instructions", """
+
+    ==============================
+
+    Hi #{user.email},
+
+    You can reset your password by visiting the URL below:
+
+    #{url}
+
+    This link will expire in 6 hours.
+
+    If you didn't request this change, please ignore this.
+
+    ==============================
+    """)
+  end
 end

--- a/apps/rogs_identity/lib/rogs_identity/accounts/user_token.ex
+++ b/apps/rogs_identity/lib/rogs_identity/accounts/user_token.ex
@@ -10,6 +10,7 @@ defmodule RogsIdentity.Accounts.UserToken do
   # since someone with access to the email may take over the account.
   @magic_link_validity_in_minutes 15
   @change_email_validity_in_days 7
+  @password_reset_validity_in_hours 6
   @session_validity_in_days 14
 
   @primary_key {:id, :binary_id, autogenerate: true}
@@ -144,6 +145,34 @@ defmodule RogsIdentity.Accounts.UserToken do
         query =
           from token in by_token_and_context_query(hashed_token, context),
             where: token.inserted_at > ago(@change_email_validity_in_days, "day")
+
+        {:ok, query}
+
+      :error ->
+        :error
+    end
+  end
+
+  @doc """
+  Checks if the password reset token is valid and returns its underlying lookup query.
+
+  The query returns the user_token found by the token, if any.
+
+  The given token is valid if it matches its hashed counterpart in the
+  database and if it has not expired (after @password_reset_validity_in_hours).
+  The context must always be "reset_password".
+  """
+  def verify_password_reset_token_query(token) do
+    case Base.url_decode64(token, padding: false) do
+      {:ok, decoded_token} ->
+        hashed_token = :crypto.hash(@hash_algorithm, decoded_token)
+
+        query =
+          from token in by_token_and_context_query(hashed_token, "reset_password"),
+            join: user in assoc(token, :user),
+            where: token.inserted_at > ago(@password_reset_validity_in_hours, "hour"),
+            where: token.sent_to == user.email,
+            select: {user, token}
 
         {:ok, query}
 

--- a/apps/rogs_identity/lib/rogs_identity/plug.ex
+++ b/apps/rogs_identity/lib/rogs_identity/plug.ex
@@ -1,0 +1,119 @@
+defmodule RogsIdentity.Plug do
+  @moduledoc """
+  Plugs for use in other applications (rogs_comm, shinkanki_web, etc.)
+
+  These plugs allow other applications to authenticate users using
+  the shared session from rogs_identity.
+
+  ## Usage
+
+  In your router:
+
+      import RogsIdentity.Plug
+
+      pipeline :browser do
+        plug :accepts, ["html"]
+        plug :fetch_session
+        plug :fetch_current_user
+      end
+
+      pipeline :require_authenticated do
+        plug :require_authenticated
+      end
+
+      scope "/", MyAppWeb do
+        pipe_through [:browser, :require_authenticated]
+
+        get "/protected", PageController, :protected
+      end
+
+  Or use the module functions directly:
+
+      plug RogsIdentity.Plug, :fetch_current_user
+      plug RogsIdentity.Plug, :require_authenticated
+  """
+
+  import Plug.Conn
+  import Phoenix.Controller
+
+  alias RogsIdentity.Accounts
+  alias RogsIdentity.Accounts.Scope
+
+  @remember_me_cookie "_rogs_identity_web_user_remember_me"
+
+  @doc """
+  Fetches the current user from the session.
+  Sets `conn.assigns.current_user` and `conn.assigns.current_scope`.
+  """
+  def fetch_current_user(conn, _opts) do
+    with {token, conn} <- ensure_user_token(conn),
+         {user, _token_inserted_at} <- Accounts.get_user_by_session_token(token) do
+      conn
+      |> assign(:current_user, user)
+      |> assign(:current_scope, Scope.for_user(user))
+    else
+      nil ->
+        conn
+        |> assign(:current_user, nil)
+        |> assign(:current_scope, Scope.for_user(nil))
+    end
+  end
+
+  @doc """
+  Requires the user to be authenticated.
+  Returns 401 Unauthorized for API requests or redirects to login for browser requests.
+  """
+  def require_authenticated(conn, _opts) do
+    if conn.assigns[:current_user] do
+      conn
+    else
+      if get_req_header(conn, "accept") |> Enum.any?(&String.contains?(&1, "json")) do
+        conn
+        |> put_status(:unauthorized)
+        |> json(%{error: "Authentication required"})
+        |> halt()
+      else
+        conn
+        |> put_flash(:error, "You must log in to access this page.")
+        |> redirect(to: get_login_url())
+        |> halt()
+      end
+    end
+  end
+
+  # Plug implementation
+  def init(opts), do: opts
+
+  def call(conn, :fetch_current_user), do: fetch_current_user(conn, [])
+  def call(conn, :require_authenticated), do: require_authenticated(conn, [])
+
+  def call(conn, opts) when is_list(opts) do
+    case Keyword.get(opts, :action) do
+      :fetch_current_user -> fetch_current_user(conn, opts)
+      :require_authenticated -> require_authenticated(conn, opts)
+      _ -> conn
+    end
+  end
+
+  # Private helpers
+
+  defp ensure_user_token(conn) do
+    if token = get_session(conn, :user_token) do
+      {token, conn}
+    else
+      conn = fetch_cookies(conn, signed: [@remember_me_cookie])
+
+      if token = conn.cookies[@remember_me_cookie] do
+        {token, put_session(conn, :user_token, token)}
+      else
+        nil
+      end
+    end
+  end
+
+  defp get_login_url do
+    # Default to rogs_identity login URL
+    # Can be configured via application config
+    Application.get_env(:rogs_identity, :login_url, "http://localhost:4000/users/log-in")
+  end
+end

--- a/apps/rogs_identity/lib/rogs_identity_web/controllers/api/auth_controller.ex
+++ b/apps/rogs_identity/lib/rogs_identity_web/controllers/api/auth_controller.ex
@@ -1,0 +1,155 @@
+defmodule RogsIdentityWeb.Api.AuthController do
+  use RogsIdentityWeb, :controller
+
+  alias RogsIdentity.Accounts
+
+  @doc """
+  Login endpoint for API.
+  Accepts email/password or magic link token.
+  """
+  def login(conn, %{"email" => email, "password" => password}) do
+    case Accounts.get_user_by_email_and_password(email, password) do
+      nil ->
+        conn
+        |> put_status(:unauthorized)
+        |> json(%{error: "Invalid email or password"})
+
+      user ->
+        token = Accounts.generate_user_session_token(user)
+        conn = put_token_in_session(conn, token)
+
+        json(conn, %{
+          success: true,
+          user: %{
+            id: user.id,
+            email: user.email,
+            name: user.name
+          },
+          token: token
+        })
+    end
+  end
+
+  def login(conn, %{"token" => token}) do
+    case Accounts.login_user_by_magic_link(token) do
+      {:ok, {user, _tokens_to_disconnect}} ->
+        session_token = Accounts.generate_user_session_token(user)
+        conn = put_token_in_session(conn, session_token)
+
+        json(conn, %{
+          success: true,
+          user: %{
+            id: user.id,
+            email: user.email,
+            name: user.name
+          },
+          token: session_token
+        })
+
+      _ ->
+        conn
+        |> put_status(:unauthorized)
+        |> json(%{error: "Invalid or expired token"})
+    end
+  end
+
+  def login(conn, _params) do
+    conn
+    |> put_status(:bad_request)
+    |> json(%{error: "Missing required parameters: email and password, or token"})
+  end
+
+  @doc """
+  Register endpoint for API.
+  """
+  def register(conn, %{"email" => email, "name" => name}) do
+    case Accounts.register_user(%{email: email, name: name}) do
+      {:ok, user} ->
+        # Generate session token and log in the user
+        token = Accounts.generate_user_session_token(user)
+        conn = put_token_in_session(conn, token)
+
+        json(conn, %{
+          success: true,
+          user: %{
+            id: user.id,
+            email: user.email,
+            name: user.name,
+            confirmed_at: user.confirmed_at
+          },
+          token: token
+        })
+
+      {:error, changeset} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> json(%{
+          error: "Validation failed",
+          errors: format_changeset_errors(changeset)
+        })
+    end
+  end
+
+  def register(conn, _params) do
+    conn
+    |> put_status(:bad_request)
+    |> json(%{error: "Missing required parameters: email and name"})
+  end
+
+  @doc """
+  Get current authenticated user information.
+  """
+  def me(conn, _params) do
+    case conn.assigns.current_scope do
+      %{user: user} when not is_nil(user) ->
+        json(conn, %{
+          success: true,
+          user: %{
+            id: user.id,
+            email: user.email,
+            name: user.name,
+            confirmed_at: user.confirmed_at
+          }
+        })
+
+      _ ->
+        conn
+        |> put_status(:unauthorized)
+        |> json(%{error: "Not authenticated"})
+    end
+  end
+
+  @doc """
+  Logout endpoint for API.
+  """
+  def logout(conn, _params) do
+    user_token = get_session(conn, :user_token)
+    user_token && Accounts.delete_user_session_token(user_token)
+
+    if live_socket_id = get_session(conn, :live_socket_id) do
+      RogsIdentityWeb.Endpoint.broadcast(live_socket_id, "disconnect", %{})
+    end
+
+    conn
+    |> configure_session(drop: true)
+    |> json(%{success: true, message: "Logged out successfully"})
+  end
+
+  # Helper functions
+
+  defp put_token_in_session(conn, token) do
+    conn
+    |> put_session(:user_token, token)
+    |> put_session(:live_socket_id, user_session_topic(token))
+  end
+
+  defp user_session_topic(token), do: "users_sessions:#{Base.url_encode64(token)}"
+
+  defp format_changeset_errors(changeset) do
+    Ecto.Changeset.traverse_errors(changeset, fn {msg, opts} ->
+      Enum.reduce(opts, msg, fn {key, value}, acc ->
+        String.replace(acc, "%{#{key}}", to_string(value))
+      end)
+    end)
+  end
+end

--- a/apps/rogs_identity/lib/rogs_identity_web/live/user_live/forgot_password.ex
+++ b/apps/rogs_identity/lib/rogs_identity_web/live/user_live/forgot_password.ex
@@ -1,0 +1,87 @@
+defmodule RogsIdentityWeb.UserLive.ForgotPassword do
+  use RogsIdentityWeb, :live_view
+
+  alias RogsIdentity.Accounts
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <Layouts.app flash={@flash} current_scope={@current_scope}>
+      <div class="mx-auto max-w-sm space-y-4">
+        <div class="text-center">
+          <.header>
+            <p>Forgot your password?</p>
+            <:subtitle>
+              We'll send password reset instructions to your email
+            </:subtitle>
+          </.header>
+        </div>
+
+        <div :if={local_mail_adapter?()} class="alert alert-info">
+          <.icon name="hero-information-circle" class="size-6 shrink-0" />
+          <div>
+            <p>You are running the local mail adapter.</p>
+            <p>
+              To see sent emails, visit <.link href="/dev/mailbox" class="underline">the mailbox page</.link>.
+            </p>
+          </div>
+        </div>
+
+        <.form
+          :let={f}
+          for={@form}
+          id="forgot_password_form"
+          phx-submit="submit"
+        >
+          <.input
+            field={f[:email]}
+            type="email"
+            label="Email"
+            autocomplete="username"
+            required
+            phx-mounted={JS.focus()}
+          />
+          <.button class="btn btn-primary w-full">
+            Send reset instructions <span aria-hidden="true">→</span>
+          </.button>
+        </.form>
+
+        <div class="text-center">
+          <.link navigate={~p"/users/log-in"} class="text-sm font-semibold">
+            Back to log in
+          </.link>
+        </div>
+      </div>
+    </Layouts.app>
+    """
+  end
+
+  @impl true
+  def mount(_params, _session, socket) do
+    form = to_form(%{"email" => ""}, as: "user")
+    {:ok, assign(socket, form: form)}
+  end
+
+  @impl true
+  def handle_event("submit", %{"user" => %{"email" => email}}, socket) do
+    if user = Accounts.get_user_by_email(email) do
+      Accounts.deliver_password_reset_instructions(
+        user,
+        &url(~p"/users/reset-password/#{&1}")
+      )
+    end
+
+    info =
+      "If your email is in our system, you will receive instructions to reset your password shortly."
+
+    {:noreply,
+     socket
+     |> put_flash(:info, info)
+     |> push_navigate(to: ~p"/users/log-in")}
+  end
+
+  defp local_mail_adapter? do
+    Application.get_env(:rogs_identity, RogsIdentity.Mailer)[:adapter] ==
+      Swoosh.Adapters.Local
+  end
+end

--- a/apps/rogs_identity/lib/rogs_identity_web/live/user_live/login.ex
+++ b/apps/rogs_identity/lib/rogs_identity_web/live/user_live/login.ex
@@ -87,6 +87,12 @@ defmodule RogsIdentityWeb.UserLive.Login do
             Log in only this time
           </.button>
         </.form>
+
+        <div class="text-center mt-4">
+          <.link navigate={~p"/users/forgot-password"} class="text-sm font-semibold">
+            Forgot your password?
+          </.link>
+        </div>
       </div>
     </Layouts.app>
     """

--- a/apps/rogs_identity/lib/rogs_identity_web/user_auth.ex
+++ b/apps/rogs_identity/lib/rogs_identity_web/user_auth.ex
@@ -279,6 +279,45 @@ defmodule RogsIdentityWeb.UserAuth do
     end
   end
 
+  @doc """
+  Plug for API routes that require the user to be authenticated.
+  Returns JSON error response instead of redirecting.
+  """
+  def require_authenticated_api(conn, _opts) do
+    if conn.assigns.current_scope && conn.assigns.current_scope.user do
+      conn
+    else
+      conn
+      |> put_status(:unauthorized)
+      |> json(%{error: "Authentication required"})
+      |> halt()
+    end
+  end
+
+  @doc """
+  Fetches the current scope for API routes.
+  Similar to fetch_current_scope_for_user but optimized for API.
+  """
+  def fetch_current_scope_for_api(conn, _opts) do
+    with {token, conn} <- ensure_user_token(conn),
+         {user, _token_inserted_at} <- Accounts.get_user_by_session_token(token) do
+      assign(conn, :current_scope, Scope.for_user(user))
+    else
+      nil -> assign(conn, :current_scope, Scope.for_user(nil))
+    end
+  end
+
+  # Plug implementation for fetch_current_scope_for_api
+  def init(opts), do: opts
+
+  def call(conn, opts) when is_list(opts) do
+    case Keyword.get(opts, :action) do
+      :fetch_current_scope_for_api -> fetch_current_scope_for_api(conn, opts)
+      :require_authenticated_api -> require_authenticated_api(conn, opts)
+      _ -> conn
+    end
+  end
+
   defp maybe_store_return_to(%{method: "GET"} = conn) do
     put_session(conn, :user_return_to, current_path(conn))
   end

--- a/apps/shinkanki_web/lib/shinkanki_web_web/router.ex
+++ b/apps/shinkanki_web/lib/shinkanki_web_web/router.ex
@@ -1,6 +1,8 @@
 defmodule ShinkankiWebWeb.Router do
   use ShinkankiWebWeb, :router
 
+  import RogsIdentity.Plug
+
   pipeline :browser do
     plug :accepts, ["html"]
     plug :fetch_session
@@ -8,6 +10,11 @@ defmodule ShinkankiWebWeb.Router do
     plug :put_root_layout, html: {ShinkankiWebWeb.Layouts, :root}
     plug :protect_from_forgery
     plug :put_secure_browser_headers
+    plug :fetch_current_user
+  end
+
+  pipeline :authenticated do
+    plug :require_authenticated
   end
 
   pipeline :api do

--- a/apps/shinkanki_web/mix.exs
+++ b/apps/shinkanki_web/mix.exs
@@ -44,6 +44,7 @@ defmodule ShinkankiWeb.MixProject do
   # Type `mix help deps` for examples and options.
   defp deps do
     [
+      {:rogs_identity, in_umbrella: true},
       {:phoenix, "~> 1.8.1"},
       {:phoenix_html, "~> 4.1"},
       {:phoenix_live_reload, "~> 1.2", only: :dev},


### PR DESCRIPTION
- Add JSON API endpoints (/api/auth/login, /api/auth/logout, /api/auth/register, /api/auth/me)
- Implement API authentication plugs (require_authenticated_api, fetch_current_scope_for_api)
- Create RogsIdentity.Plug module for other apps to use authentication
- Integrate authentication with rogs_comm and shinkanki_web apps
- Implement password reset functionality (forgot password and reset password)
- Add password reset LiveView pages and routes
- Add link to forgot password from login page