### PR TITLE
feat: エンディング分岐システムの実装

### DIFF
--- a/apps/shinkanki/lib/shinkanki/card.ex
+++ b/apps/shinkanki/lib/shinkanki/card.ex
@@ -10,7 +10,8 @@ defmodule Shinkanki.Card do
           type: card_type(),
           name: String.t(),
           description: String.t(),
-          cost: integer(), # For action cards (P)
+          # For action cards (P)
+          cost: integer(),
           # Base effect for action cards
           effect: map(),
           # Tags for compatibility (e.g., :nature, :craft, :community)
@@ -168,7 +169,8 @@ defmodule Shinkanki.Card do
         name: "修理 (Repair)",
         description: "Fix broken things.",
         cost: 5,
-        effect: %{social: 2, forest: 2}, # Reduce waste
+        # Reduce waste
+        effect: %{social: 2, forest: 2},
         tags: [:fix, :craft]
       }
     ]
@@ -329,7 +331,8 @@ defmodule Shinkanki.Card do
         type: :project,
         name: "森の祝祭 (Forest Festival)",
         description: "A grand festival in the forest.",
-        cost: 50, # High cost
+        # High cost
+        cost: 50,
         effect: %{forest: 10, culture: 10, social: 10},
         tags: [:event, :nature, :community],
         unlock_condition: %{forest: 80, culture: 60}

--- a/apps/shinkanki/test/shinkanki/game_action_test.exs
+++ b/apps/shinkanki/test/shinkanki/game_action_test.exs
@@ -103,7 +103,8 @@ defmodule Shinkanki.GameActionTest do
       # Event cards can reduce stats, so we use a more lenient check
       assert game_after_project.forest >= 70
       assert game_after_project.culture >= 50
-      assert game_after_project.social >= 0  # Event cards can reduce social significantly
+      # Event cards can reduce social significantly
+      assert game_after_project.social >= 0
 
       # Project cost: 50. After action, currency is 950.
       # But since turn advances (1 player ready), demurrage applies: floor(950 * 0.9) = 855

--- a/apps/shinkanki/test/shinkanki/game_ending_test.exs
+++ b/apps/shinkanki/test/shinkanki/game_ending_test.exs
@@ -1,0 +1,208 @@
+defmodule Shinkanki.GameEndingTest do
+  use ExUnit.Case
+  alias Shinkanki.Game
+
+  describe "ending type determination" do
+    test "神々の祝福エンディング (L >= 40)" do
+      # Turn 21 with high Life Index
+      # Disable event cards by emptying the deck
+      game = %Game{
+        Game.new("room")
+        | turn: 20,
+          forest: 20,
+          culture: 15,
+          social: 10,
+          life_index: 45,
+          event_deck: [],
+          event_discard_pile: []
+      }
+
+      result = Game.next_turn(game)
+
+      assert result.status == :won
+      assert result.ending_type == :blessing
+      assert Game.ending_name(result.ending_type) == "🌈 神々の祝福エンディング"
+    end
+
+    test "浄化の兆しエンディング (30 <= L < 40)" do
+      # Turn 21 with moderate Life Index
+      # Disable event cards by emptying the deck
+      game = %Game{
+        Game.new("room")
+        | turn: 20,
+          forest: 12,
+          culture: 10,
+          social: 8,
+          life_index: 30,
+          event_deck: [],
+          event_discard_pile: []
+      }
+
+      result = Game.next_turn(game)
+
+      assert result.status == :won
+      assert result.ending_type == :purification
+      assert Game.ending_name(result.ending_type) == "🌿 浄化の兆しエンディング"
+    end
+
+    test "揺らぎの未来エンディング (20 <= L < 30)" do
+      # Turn 21 with low Life Index
+      # Disable event cards by emptying the deck
+      game = %Game{
+        Game.new("room")
+        | turn: 20,
+          forest: 8,
+          culture: 7,
+          social: 5,
+          life_index: 20,
+          event_deck: [],
+          event_discard_pile: []
+      }
+
+      result = Game.next_turn(game)
+
+      assert result.status == :lost
+      assert result.ending_type == :uncertainty
+      assert Game.ending_name(result.ending_type) == "🌙 揺らぎの未来エンディング"
+    end
+
+    test "神々の嘆きエンディング (L <= 19)" do
+      # Turn 21 with very low Life Index
+      # Disable event cards by emptying the deck
+      game = %Game{
+        Game.new("room")
+        | turn: 20,
+          forest: 7,
+          culture: 6,
+          social: 5,
+          life_index: 18,
+          event_deck: [],
+          event_discard_pile: []
+      }
+
+      result = Game.next_turn(game)
+
+      assert result.status == :lost
+      assert result.ending_type == :lament
+      assert Game.ending_name(result.ending_type) == "🔥 神々の嘆き（文明崩壊）"
+    end
+
+    test "即時ゲームオーバー (F=0 or K=0 or S=0)" do
+      # Forest becomes 0
+      # Disable event cards by emptying the deck
+      game = %Game{
+        Game.new("room")
+        | turn: 5,
+          forest: 0,
+          culture: 10,
+          social: 10,
+          life_index: 20,
+          event_deck: [],
+          event_discard_pile: []
+      }
+
+      result = Game.next_turn(game)
+
+      assert result.status == :lost
+      assert result.ending_type == :instant_loss
+      assert Game.ending_name(result.ending_type) == "💀 即時ゲームオーバー"
+
+      # Culture becomes 0
+      game2 = %Game{
+        Game.new("room")
+        | turn: 5,
+          forest: 10,
+          culture: 0,
+          social: 10,
+          life_index: 20,
+          event_deck: [],
+          event_discard_pile: []
+      }
+
+      result2 = Game.next_turn(game2)
+
+      assert result2.status == :lost
+      assert result2.ending_type == :instant_loss
+
+      # Social becomes 0
+      game3 = %Game{
+        Game.new("room")
+        | turn: 5,
+          forest: 10,
+          culture: 10,
+          social: 0,
+          life_index: 20,
+          event_deck: [],
+          event_discard_pile: []
+      }
+
+      result3 = Game.next_turn(game3)
+
+      assert result3.status == :lost
+      assert result3.ending_type == :instant_loss
+    end
+
+    test "ending boundaries are correct" do
+      # Disable event cards for all boundary tests
+      base_game = %Game{Game.new("room") | event_deck: [], event_discard_pile: []}
+
+      # Test boundary at L = 40 (should be blessing)
+      game_40 = %{base_game | turn: 20, forest: 15, culture: 15, social: 10, life_index: 40}
+      result_40 = Game.next_turn(game_40)
+      assert result_40.ending_type == :blessing
+
+      # Test boundary at L = 39 (should be purification)
+      game_39 = %{base_game | turn: 20, forest: 15, culture: 14, social: 10, life_index: 39}
+      result_39 = Game.next_turn(game_39)
+      assert result_39.ending_type == :purification
+
+      # Test boundary at L = 30 (should be purification)
+      game_30 = %{base_game | turn: 20, forest: 12, culture: 10, social: 8, life_index: 30}
+      result_30 = Game.next_turn(game_30)
+      assert result_30.ending_type == :purification
+
+      # Test boundary at L = 29 (should be uncertainty)
+      game_29 = %{base_game | turn: 20, forest: 12, culture: 9, social: 8, life_index: 29}
+      result_29 = Game.next_turn(game_29)
+      assert result_29.ending_type == :uncertainty
+
+      # Test boundary at L = 20 (should be uncertainty)
+      game_20 = %{base_game | turn: 20, forest: 8, culture: 7, social: 5, life_index: 20}
+      result_20 = Game.next_turn(game_20)
+      assert result_20.ending_type == :uncertainty
+
+      # Test boundary at L = 19 (should be lament)
+      game_19 = %{base_game | turn: 20, forest: 7, culture: 7, social: 5, life_index: 19}
+      result_19 = Game.next_turn(game_19)
+      assert result_19.ending_type == :lament
+    end
+
+    test "ending descriptions are available" do
+      assert Game.ending_description(:blessing) != nil
+      assert Game.ending_description(:purification) != nil
+      assert Game.ending_description(:uncertainty) != nil
+      assert Game.ending_description(:lament) != nil
+      assert Game.ending_description(:instant_loss) != nil
+      assert Game.ending_description(nil) == nil
+    end
+
+    test "game continues playing if turn <= 20 and stats > 0" do
+      # Turn 20 should not trigger ending (turn > 20 is required)
+      game = %Game{
+        Game.new("room")
+        | turn: 19,
+          forest: 10,
+          culture: 10,
+          social: 10,
+          life_index: 30,
+          event_deck: [],
+          event_discard_pile: []
+      }
+
+      result = Game.next_turn(game)
+
+      assert result.status == :playing
+      assert result.ending_type == nil
+    end
+  end
+end

--- a/apps/shinkanki/test/shinkanki/game_event_test.exs
+++ b/apps/shinkanki/test/shinkanki/game_event_test.exs
@@ -46,9 +46,10 @@ defmodule Shinkanki.GameEventTest do
 
       # Check that event is logged
       assert length(new_game.logs) > 0
+
       assert Enum.any?(new_game.logs, fn log ->
-        String.contains?(log, "Event:")
-      end)
+               String.contains?(log, "Event:")
+             end)
     end
 
     test "event card effect is applied correctly" do
@@ -70,18 +71,27 @@ defmodule Shinkanki.GameEventTest do
     end
 
     test "event discard pile is used when event deck is empty" do
-      game = %Game{Game.new("room_1") | event_deck: [], event_discard_pile: [:e_harvest_festival, :e_drought]}
+      game = %Game{
+        Game.new("room_1")
+        | event_deck: [],
+          event_discard_pile: [:e_harvest_festival, :e_drought]
+      }
 
       # Should reshuffle discard pile and draw from it
       new_game = Game.next_turn(game)
 
       # Event should be drawn from reshuffled discard
       assert new_game.current_event != nil
-      assert length(new_game.event_discard_pile) < 2  # One card was drawn
+      # One card was drawn
+      assert length(new_game.event_discard_pile) < 2
     end
 
     test "current event is cleared and moved to discard at turn end" do
-      game = %Game{Game.new("room_1") | current_event: :e_harvest_festival, event_discard_pile: []}
+      game = %Game{
+        Game.new("room_1")
+        | current_event: :e_harvest_festival,
+          event_discard_pile: []
+      }
 
       # Advance turn
       new_game = Game.next_turn(game)
@@ -114,16 +124,22 @@ defmodule Shinkanki.GameEventTest do
 
       # Check that disaster events have negative effects
       disaster = Enum.find(events, &(&1.id == :e_drought))
-      assert disaster.effect.forest < 0 || disaster.effect.culture < 0 || disaster.effect.social < 0
+
+      assert disaster.effect.forest < 0 || disaster.effect.culture < 0 ||
+               disaster.effect.social < 0
 
       # Check that festival events have positive effects
       festival = Enum.find(events, &(&1.id == :e_harvest_festival))
-      assert festival.effect.forest > 0 || festival.effect.culture > 0 || festival.effect.social > 0
+
+      assert festival.effect.forest > 0 || festival.effect.culture > 0 ||
+               festival.effect.social > 0
 
       # Check that temptation events increase currency but may have negative side effects
       temptation = Enum.find(events, &(&1.id == :e_quick_profit))
       assert temptation.effect.currency > 0
-      assert temptation.effect.forest < 0 || temptation.effect.culture < 0 || temptation.effect.social < 0
+
+      assert temptation.effect.forest < 0 || temptation.effect.culture < 0 ||
+               temptation.effect.social < 0
     end
   end
 end

--- a/apps/shinkanki/test/shinkanki/game_test.exs
+++ b/apps/shinkanki/test/shinkanki/game_test.exs
@@ -47,7 +47,8 @@ defmodule Shinkanki.GameTest do
       assert next_game.turn == 2
       # Currency 100 * 0.9 = 90, but event cards may modify currency
       # So we check that demurrage was applied (currency <= 100)
-      assert next_game.currency <= 120  # Allow for event card effects
+      # Allow for event card effects
+      assert next_game.currency <= 120
     end
 
     test "does not change state if game is already over" do
@@ -87,13 +88,13 @@ defmodule Shinkanki.GameTest do
     end
 
     test "detects loss if stats drop to 0 during turn update (e.g. if demurrage affected life index, though it doesn't directly)" do
-       # Note: Demurrage affects Currency (P), which is NOT part of Life Index (L = F+K+S).
-       # So pure turn advancement only affects P.
-       # However, if we had logic where P=0 affects others, we'd test it here.
-       # For now, just ensure standard turn flow works.
-       game = Game.new("room_1")
-       next_game = Game.next_turn(game)
-       assert next_game.status == :playing
+      # Note: Demurrage affects Currency (P), which is NOT part of Life Index (L = F+K+S).
+      # So pure turn advancement only affects P.
+      # However, if we had logic where P=0 affects others, we'd test it here.
+      # For now, just ensure standard turn flow works.
+      game = Game.new("room_1")
+      next_game = Game.next_turn(game)
+      assert next_game.status == :playing
     end
   end
 end

--- a/apps/shinkanki/test/shinkanki/replay_test.exs
+++ b/apps/shinkanki/test/shinkanki/replay_test.exs
@@ -70,14 +70,27 @@ defmodule Shinkanki.ReplayTest do
     end
   end
 
-  defp apply_action_log_manual(game, %ActionLog{action: "join_player", player_id: player_id, payload: payload}) do
-    case Game.join(game, player_id, payload[:name] || payload["name"], payload[:talent_ids] || payload["talent_ids"]) do
+  defp apply_action_log_manual(game, %ActionLog{
+         action: "join_player",
+         player_id: player_id,
+         payload: payload
+       }) do
+    case Game.join(
+           game,
+           player_id,
+           payload[:name] || payload["name"],
+           payload[:talent_ids] || payload["talent_ids"]
+         ) do
       {:ok, new_game} -> new_game
       _ -> game
     end
   end
 
-  defp apply_action_log_manual(game, %ActionLog{action: "play_action", player_id: player_id, payload: payload}) do
+  defp apply_action_log_manual(game, %ActionLog{
+         action: "play_action",
+         player_id: player_id,
+         payload: payload
+       }) do
     action_id = payload[:action_id] || payload["action_id"]
     talent_ids = payload[:talent_ids] || payload["talent_ids"] || []
 


### PR DESCRIPTION
- 5種類のエンディングタイプを追加（神々の祝福、浄化の兆し、揺らぎの未来、神々の嘆き、即時ゲームオーバー）
- Life Indexに基づくエンディング判定ロジック
- エンディング名と説明文を取得する関数を追加
- 境界値テストを含む包括的なテストスイート